### PR TITLE
解决 .cache 文件夹写入权限问题

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -2,7 +2,7 @@ var fs = require('fs')
 var path = require('path')
 var rimraf = require('rimraf')
 
-var cachePath = path.join(__dirname, '../.cache')
+var cachePath = path.join(__dirname, '../_cache')
 var cache = {
   save(filename, content) {
     var filePath = path.join(cachePath, filename + '.vue')


### PR DESCRIPTION
环境：macOS Sierra
问题：执行 markdown 编译时提示权限不够无法写入 .cache 文件夹。
原因：macOS 下，以 "." 开头的文件 / 文件夹默认属于隐藏文件，没有写入权限。
解决方法：将 cache.js 中的 '../.cache' 路径改为 '../_cache'，绕过默认的隐藏文件规则。
错误信息：
```bash
ERROR in EACCES: permission denied, unlink '/project-path/node_modules/vue-markdown-loader/.cache/component.vue'
```