### PR TITLE
use v-pre to disable vue compilation

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -6,7 +6,7 @@ var markdownCompilerPath = path.resolve(__dirname, 'markdown-compiler.js')
 module.exports = function (source) {
   this.cacheable()
 
-  this.options.__vueMarkdownOptions__ = this.query || {}
+  this.options.__vueMarkdownOptions__ = this.query || this.vueMarkdown || this.options.vueMarkdown || {}
 
   var filePath = this.resourcePath
 

--- a/lib/markdown-compiler.js
+++ b/lib/markdown-compiler.js
@@ -4,12 +4,13 @@ var cheerio = require('cheerio')
 var markdown = require('markdown-it')
 
 /**
- * `{{ }}` => `<span>{{</span> <span>}}</span>`
+ * `<pre></pre>` => `<pre v-pre></pre>`
+ * `<code></code>` => `<code v-pre></code>`
  * @param  {string} str
  * @return {string}
  */
-var replaceDelimiters = function (str) {
-  return str.replace(/({{|}})/g, '<span>$1</span>')
+var addVuePreviewAttr = function (str) {
+  return str.replace(/(<pre|<code)/g, '$1 v-pre')
 }
 
 /**
@@ -22,9 +23,7 @@ var renderHighlight = function (str, lang) {
     return ''
   }
 
-  try {
-    return replaceDelimiters(hljs.highlight(lang, str, true).value)
-  } catch (err) {}
+  return hljs.highlight(lang, str, true).value
 }
 
 /**
@@ -36,12 +35,12 @@ var renderVueTemplate = function (html) {
   var $ = cheerio.load(html, {
     decodeEntities: false,
     lowerCaseAttributeNames: false,
-    lowerCaseTags: false
+    lowerCaseTags: false,
   })
 
   var output = {
     style: $.html('style'),
-    script: $.html('script')
+    script: $.html('script'),
   }
   var result
 
@@ -57,22 +56,23 @@ var renderVueTemplate = function (html) {
 
 module.exports = function (source) {
   this.cacheable && this.cacheable()
-  var parser
+  var parser, preprocess
   var params = loaderUtils.parseQuery(this.query) || {}
-  var vueMarkdownOptions = Object.create(this.options.__vueMarkdownOptions__ ? this.options.__vueMarkdownOptions__.__proto__ : {})
-  var opts = Object.assign(vueMarkdownOptions, params, this.options.__vueMarkdownOptions__, this.vueMarkdown, this.options.vueMarkdown)
+  var vueMarkdownOptions = this.options.__vueMarkdownOptions__
+  var opts = Object.create(vueMarkdownOptions.__proto__) // inherit prototype
+  opts = Object.assign(opts, params, vueMarkdownOptions) // assign attributes
 
-  if ({}.toString.call(opts.render) === '[object Function]') {
+  if (typeof opts.render === 'function') {
     parser = opts
   } else {
     opts = Object.assign({
       preset: 'default',
       html: true,
-      highlight: renderHighlight
+      highlight: renderHighlight,
     }, opts)
 
     var plugins = opts.use
-    var preprocess = opts.preprocess
+    preprocess = opts.preprocess
 
     delete opts.use
     delete opts.preprocess
@@ -89,10 +89,25 @@ module.exports = function (source) {
     }
   }
 
-  var codeInlineRender = parser.renderer.rules.code_inline;
-  parser.renderer.rules.code_inline = function () {
-    return replaceDelimiters(codeInlineRender.apply(this, arguments));
+  /**
+   * override default parser rules by adding v-pre attribute on 'code' and 'pre' tags
+   * @param {Array<string>} rules rules to override
+   */
+  function overrideParserRules (rules) {
+    if (parser && parser.renderer && parser.renderer.rules) {
+      var parserRules = parser.renderer.rules
+      rules.forEach(function (rule) {
+        if (parserRules && parserRules[rule]) {
+          var defaultRule = parserRules[rule]
+          parserRules[rule] = function () {
+            return addVuePreviewAttr(defaultRule.apply(this, arguments))
+          }
+        }
+      })
+    }
   }
+
+  overrideParserRules([ 'code_inline', 'code_block', 'fence' ])
 
   if (preprocess) {
     source = preprocess.call(this, parser, source)


### PR DESCRIPTION
1. use `v-pre` to disable vue compilation instead of appending `span` tags
2. disable vue compilation for `code_inline`, `code_block` and `fence` rules
3. optimize code for both webpack2.0 options and webpack1.x `vueMarkdown` options (**webpack1.x support is not tested**)