### PR TITLE
append resourceQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ Since `v2.0.0`,  this loader will automatically extract script and style tags fr
 }
 ```
 
+### wrapper
+
+You can customize wrapper tag no matter html element tag or vue component tag. Default is 'section'
+
+```js
+{
+  test: /\.md$/,
+  loader: 'vue-markdown-loader',
+  options: {
+    wrapper: 'article',
+  }
+}
+```
+
 ### markdownIt
 
 reference [markdown-it](https://github.com/markdown-it/markdown-it#init-with-presets-and-options)

--- a/lib/core.js
+++ b/lib/core.js
@@ -11,7 +11,7 @@ module.exports = function (source) {
   var filePath = this.resourcePath
 
   var result = 'module.exports = require(' +
-    loaderUtils.stringifyRequest(this, '!!vue-loader!' + markdownCompilerPath + '?raw!' + filePath) +
+    loaderUtils.stringifyRequest(this, '!!vue-loader!' + markdownCompilerPath + '?raw!' + filePath + this.resourceQuery) +
   ');'
 
   return result

--- a/lib/markdown-compiler.js
+++ b/lib/markdown-compiler.js
@@ -32,7 +32,7 @@ var renderHighlight = function(str, lang) {
  * @param  {[type]} html [description]
  * @return {[type]}      [description]
  */
-var renderVueTemplate = function(html) {
+var renderVueTemplate = function(html, wrapper) {
   var $ = cheerio.load(html, {
     decodeEntities: false,
     lowerCaseAttributeNames: false,
@@ -49,9 +49,9 @@ var renderVueTemplate = function(html) {
   $("script").remove();
 
   result =
-    "<template><section>" +
+    `<template><${wrapper}>` +
     $.html() +
-    "</section></template>\n" +
+    `</${wrapper}></template>\n` +
     output.style +
     "\n" +
     output.script;
@@ -81,7 +81,8 @@ module.exports = function(source) {
       {
         preset: "default",
         html: true,
-        highlight: renderHighlight
+        highlight: renderHighlight,
+        wrapper: 'section'
       },
       opts
     );
@@ -154,7 +155,7 @@ module.exports = function(source) {
   source = source.replace(/@/g, "__at__");
 
   var content = parser.render(source).replace(/__at__/g, "@");
-  var result = renderVueTemplate(content);
+  var result = renderVueTemplate(content, opts.wrapper);
 
   if (opts.raw) {
     return result;


### PR DESCRIPTION
有的时候会在`preprocess`方法中根据resourceQuery判断一些事情，比如要实现一个markdown的summary功能：

``` javascript
const Blog = require('./blog.md')
const BlogSummary = require('./blog.md?summary')

...

preprocess(markdownIt, source) {
    if (this.resourceQuery.includes('summary')) {
        return source.slice(0, 400);
    }
}
```

所以建议把resourceQuery带上。没有query的时候，这个字段为空，不影响其他功能。

------

添加了一个`wrapper`选项，用于修改包裹的元素，有时还可以是一个组件。