### PR TITLE
Vue Single File templates seem to only support one script tag

### DIFF
--- a/lib/markdown-compiler.js
+++ b/lib/markdown-compiler.js
@@ -41,7 +41,8 @@ var renderVueTemplate = function(html, wrapper) {
 
   var output = {
     style: $.html("style"),
-    script: $.html("script")
+    // get only the first script child. Causes issues if multiple script files in page.
+    script: $.html($('script').first()), 
   };
   var result;
 


### PR DESCRIPTION
Came across an issue when dealing with a page which had multiple `<script>` blocks. 

https://github.com/vuejs/vue-loader/issues/228

I had a main `<script>` block, and the rest were in the `html` fences. Thanks to `preventExtract: false`, these extra script tags get injected and break the component. I wish to use `preventExtract` however, only use the first `script` tag to be used for the component.

The fix I've made will take the first script block it sees as the single-file-component's script block. Not sure if this is the best way of solving this issue, open to suggestions.