### PR TITLE
Replace deprecated context properties and support webpack 4.x

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -6,8 +6,12 @@ var markdownCompilerPath = path.resolve(__dirname, 'markdown-compiler.js');
 module.exports = function(source) {
   this.cacheable();
 
-  this.options.__vueMarkdownOptions__ =
-    this.query || this.vueMarkdown || this.options.vueMarkdown || {};
+  var options = loaderUtils.getOptions(this) || {};
+  Object.defineProperty(this._compilation, '__vueMarkdownOptions__', {
+    value: options,
+    enumerable: false,
+    configurable: true
+  })
 
   var filePath = this.resourcePath;
 

--- a/lib/markdown-compiler.js
+++ b/lib/markdown-compiler.js
@@ -63,8 +63,8 @@ var renderVueTemplate = function(html, wrapper) {
 module.exports = function(source) {
   this.cacheable && this.cacheable();
   var parser, preprocess;
-  var params = loaderUtils.parseQuery(this.query) || {};
-  var vueMarkdownOptions = this.options.__vueMarkdownOptions__;
+  var params = loaderUtils.getOptions(this) || {};
+  var vueMarkdownOptions = this._compilation.__vueMarkdownOptions__;
   var opts = Object.create(vueMarkdownOptions.__proto__); // inherit prototype
   var preventExtract = false;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -446,6 +446,20 @@
         "loader-utils": "0.2.17",
         "mkdirp": "0.5.1",
         "object-assign": "4.1.1"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "0.2.17",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1",
+            "object-assign": "4.1.1"
+          }
+        }
       }
     },
     "babel-messages": {
@@ -1514,6 +1528,20 @@
         "postcss-modules-scope": "1.1.0",
         "postcss-modules-values": "1.3.0",
         "source-list-map": "0.1.8"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "0.2.17",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1",
+            "object-assign": "4.1.1"
+          }
+        }
       }
     },
     "css-select": {
@@ -3034,14 +3062,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3050,6 +3070,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -4023,14 +4051,13 @@
       "dev": true
     },
     "loader-utils": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-      "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+      "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
       "requires": {
         "big.js": "3.1.3",
         "emojis-list": "2.1.0",
-        "json5": "0.5.1",
-        "object-assign": "4.1.1"
+        "json5": "0.5.1"
       }
     },
     "lodash": {
@@ -4530,7 +4557,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object.omit": {
       "version": "2.0.1",
@@ -6391,11 +6419,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -6406,6 +6429,11 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",
@@ -6919,6 +6947,18 @@
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
           "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
           "dev": true
+        },
+        "loader-utils": {
+          "version": "0.2.17",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1",
+            "object-assign": "4.1.1"
+          }
         },
         "source-map": {
           "version": "0.5.6",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "cheerio": "^0.20.0",
     "highlight.js": "^9.4.0",
-    "loader-utils": "^0.2.15",
+    "loader-utils": "^1.1.0",
     "markdown-it": "^8.4.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
`this.options` has been removed after webpack 4.x.

 In order to support 4.x, I edit some incompatible code.